### PR TITLE
[#69] Connect extension to production urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,13 @@ cd extension && pnpm run dev
 - Go to `chrome://extensions/`
 - Enable developer mode in the top right
 - Click Load unpacked in the top left
-- Choose the folder that `pnpm run dev` told you to
+- Choose the folder that `pnpm run dev` told you to (likely `.output/chrome-mv3-dev`)
+
+### Build extension (production)
+
+- Run `pnpm run build -- --mode production`
+- This creates the extension with the `.env.production` variables - connecting it to the production website and api.
+- Load unpacked or upload to Chrome Web Store (folder is likely `.output/chrome-mv3`)
 
 ### Environments
 

--- a/extension/.env.production
+++ b/extension/.env.production
@@ -1,0 +1,3 @@
+VITE_API_HOST = "https://api.production.parakeet.vigetx.com"
+VITE_API_PORT =
+VITE_WEBSITE_URL = "https://parakeet.vigetx.com"


### PR DESCRIPTION
Addresses #69 

Create a `.env.production` for building production version of the extension with production urls. Added to the readme to document how production build works.